### PR TITLE
RHICOMPL-2708 dump the data in smaller and customizable chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker run --rm floorist \
 
 ### Floorplan file
 
-The floorplan file simply defines a list of a prefix-query pair. The prefix should be a valid folder path that will be created under the bucket if it does not exist. For the queries it is recommended to assign simpler aliases for dynamically created (joins or aggregates) columns using `AS`.
+The floorplan file simply defines a list of a prefix-query pair. The prefix should be a valid folder path that will be created under the bucket if it does not exist. For the queries it is recommended to assign simpler aliases for dynamically created (joins or aggregates) columns using `AS`. Optionally you can set a custom `chunksize` for the [query](https://pandas.pydata.org/docs/reference/api/pandas.read_sql_query.html) (default is 1000) that will serve as the maximum number of records in a single parquet file.
 
 ```yaml
 - prefix: dumps/people
@@ -45,9 +45,10 @@ The floorplan file simply defines a list of a prefix-query pair. The prefix shou
 - prefix: dumps/cities
   query: >-
     SELECT name AS city_name, zip, country FROM cities;
+  chunksize: 100
 ```
 
-The example above will create two dumps under the S3 bucket specified in the `AWS_BUCKET` environment variable into the `<prefix>/year_created=<Y>/month_created=<M>/day_created=<D>/<UUID>.parquet` file.
+The example above will create two dumps under the S3 bucket specified in the `AWS_BUCKET` environment variable into the `<prefix>/year_created=<Y>/month_created=<M>/day_created=<D>/<UUID>.parquet` files.
 
 ### Clowder - How to add Floorist to your Clowder template
 

--- a/src/floorist/floorist.py
+++ b/src/floorist/floorist.py
@@ -45,24 +45,24 @@ def main():
       try:
         logging.debug(f"Dumping #{dump_count}: {row['query']} to {row['prefix']}")
 
-        data = sqlio.read_sql_query(row['query'], conn)
-        target = '/'.join([
-          f"s3://{config.bucket_name}",
-          row['prefix'],
-          date.today().strftime('year_created=%Y/month_created=%-m/day_created=%-d'),
-          f"{uuid()}.parquet"
-        ])
+        for data in sqlio.read_sql_query(row['query'], conn, chunksize=row.get('chunksize', 1000)):
+          target = '/'.join([
+            f"s3://{config.bucket_name}",
+            row['prefix'],
+            date.today().strftime('year_created=%Y/month_created=%-m/day_created=%-d'),
+            f"{uuid()}.parquet"
+          ])
 
-        data.to_parquet(
-          path=target,
-          compression='gzip',
-          index=False,
-          storage_options={
-            'secret': config.bucket_secret_key,
-             'key' : config.bucket_access_key,
-            'client_kwargs':{'endpoint_url': config.bucket_url }
-          }
-        )
+          data.to_parquet(
+            path=target,
+            compression='gzip',
+            index=False,
+            storage_options={
+              'secret': config.bucket_secret_key,
+               'key' : config.bucket_access_key,
+              'client_kwargs':{'endpoint_url': config.bucket_url }
+            }
+          )
 
         logging.debug(f"Dumped #{dumped_count}: {row['query']} to {row['prefix']}")
 

--- a/tests/floorplan_with_large_result.yaml
+++ b/tests/floorplan_with_large_result.yaml
@@ -1,0 +1,3 @@
+- query:  SELECT x, y, z FROM GENERATE_SERIES(0,999) as x JOIN GENERATE_SERIES(0,999) as y ON 1=1 JOIN GENERATE_SERIES(0,999) as z ON 1=1;
+  prefix: series
+  chunksize: 500

--- a/tests/test_floorist.py
+++ b/tests/test_floorist.py
@@ -134,6 +134,18 @@ class TestFloorist:
         assert 'Dumped 2 from total of 2'
         assert s3.ls(env['AWS_BUCKET']) == [f"{env['AWS_BUCKET']}/numbers", f"{env['AWS_BUCKET']}/people"]
 
+    def floorplan_with_large_result(self, caplog):
+        s3 = S3FileSystem(client_kwargs={'endpoint_url': env.get('AWS_ENDPOINT')})
+        if s3.ls(env['AWS_BUCKET']) != []:  # Make sure that the bucket is empty
+            s3.rm(f"{env['AWS_BUCKET']}/*", recursive=True)
+
+        assert s3.ls(env['AWS_BUCKET']) == []
+        env['FLOORPLAN_FILE'] = 'tests/floorplan_with_large_result.yaml'
+        main()
+        assert 'Dumped 1 from total of 1'
+        assert s3.ls(env['AWS_BUCKET']) == [f"{env['AWS_BUCKET']}/series"]
+        assert len(s3.les(f"{env['AWS_BUCKET']}/series/")), 2000
+
     def test_floorplan_with_one_failing_dump(self, caplog):
         s3 = S3FileSystem(client_kwargs={'endpoint_url': env.get('AWS_ENDPOINT')})
         if s3.ls(env['AWS_BUCKET']) != []:  # Make sure that the bucket is empty


### PR DESCRIPTION
Instead of saving everything into a single big file, we're following the parquet format specification and creating multiple files with a predefined maximum number of records. This number is 1000 be default, but it can be adjusted by setting the `chunksize` parameter for each query.