### PR TITLE
fix(uuid): RHICOMPL-3006 detect and convert UUID columns to string

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -166,6 +166,7 @@ echo '===================================='
 echo '===     Running Tests           ===='
 echo '===================================='
 set +e
+docker exec "$DB_CONTAINER_ID" /bin/bash -c "psql floorist -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'"
 docker exec "$TEST_CONTAINER_ID" /bin/bash -c "pytest --junitxml=test-report.xml tests"
 TEST_RESULT=$?
 set -e

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - POSTGRESQL_PASSWORD=floorist
       - POSTGRESQL_USER=floorist
       - POSTGRESQL_DATABASE=floorist
+      - POSTGRESQL_ADMIN_PASSWORD=flooristadmin
     ports:
       - 5432:5432
     volumes:
@@ -33,4 +34,19 @@ services:
       until /usr/bin/mc config host add myminio http://minio:9000 floorist floorist >/dev/null; do sleep 1; done ;
       /usr/bin/mc mb myminio/floorist;
       /usr/bin/mc policy set download myminio/floorist;
+      exit 0;'
+  setupdb:
+    image: registry.access.redhat.com/ubi9/ubi-minimal
+    depends_on:
+      - db
+    links:
+      - db
+    environment:
+      - PGHOST=db
+      - PGDATABASE=floorist
+      - PGUSER=postgres
+      - PGPASSWORD=flooristadmin
+    command: /bin/sh -c '
+      microdnf install -y postgresql;
+      psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";";
       exit 0;'

--- a/tests/floorplan_valid.yaml
+++ b/tests/floorplan_valid.yaml
@@ -1,2 +1,2 @@
-- query: SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS t (num,letter);
-  prefix: 
+- query: SELECT * FROM (VALUES (uuid_generate_v1(), 'one'), (uuid_generate_v1(), 'two'), (uuid_generate_v1(), 'three')) AS t (num,letter);
+  prefix: valid

--- a/tests/test_floorist.py
+++ b/tests/test_floorist.py
@@ -177,3 +177,13 @@ class TestFloorist:
         assert 'ProgrammingError' in caplog.text
         assert 'Dumped 1 from total of 2'
         assert wr.s3.list_directories(prefix, boto3_session=session) == [f"{prefix}/numbers/"]
+
+    def test_floorplan_valid(self, caplog, session):
+        prefix = f"s3://{env['AWS_BUCKET']}"
+        env['FLOORPLAN_FILE'] = 'tests/floorplan_valid.yaml'
+        main()
+        assert 'Dumped 1 from total of 1'
+        assert wr.s3.list_directories(prefix, boto3_session=session) == [f"{prefix}/valid/"]
+        assert len(wr.s3.list_objects(f"{prefix}/valid/", boto3_session=session)) == 1
+        df = wr.s3.read_parquet(f"{prefix}/valid/", boto3_session=session)
+        assert len(df), 3


### PR DESCRIPTION
On the first iteration, detecting UUID columns and building a dictionary that can be consumed by `df.asType`. Not an ideal solution, we should probably experiment with custom types in pandas/pyarrow, but it fixes the problem.