### PR TITLE
fix(Dockerfile): add procps-ng with pgrep for probes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/app-root
 
 COPY --chown=1001:0 --from=build /opt/app-root /opt/app-root
 
-RUN microdnf install -y python39 libpq && \
+RUN microdnf install -y python39 libpq procps-ng && \
     chown 1001:0 /opt/app-root
 
 USER 1001


### PR DESCRIPTION
Adds procps-ng dependency that includes pgrep used for k8s probes.

RHICOMPL-3047