### PR TITLE
chore(Dockerfile): RHICOMPL-3060 update base image to ubi9-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS build
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS build
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
 USER 0
 
-RUN microdnf install -y python39-devel postgresql-devel gcc && \
+RUN microdnf install -y python3-devel postgresql-devel gcc && \
     pip3 install virtualenv                                 && \
     mkdir -p /opt/app-root                                  && \
     chown 1001:0 /opt/app-root
@@ -19,7 +19,7 @@ RUN virtualenv .                          && \
     bin/pip install -r requirements.txt . && \
     rm -rf \~
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal as base
+FROM registry.access.redhat.com/ubi9/ubi-minimal as base
 
 USER 0
 
@@ -27,7 +27,7 @@ WORKDIR /opt/app-root
 
 COPY --chown=1001:0 --from=build /opt/app-root /opt/app-root
 
-RUN microdnf install -y python39 libpq procps-ng && \
+RUN microdnf install -y python3 libpq procps-ng && \
     chown 1001:0 /opt/app-root
 
 USER 1001


### PR DESCRIPTION
The default version of python here is `3.9`, so no need for explicit setting.