### PR TITLE
build: refactor Dockerfile and build latest tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
+ARG deps="python3 libpq procps-ng"
+ARG devDeps="python3-devel postgresql-devel gcc"
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS build
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
 USER 0
 
-RUN microdnf install -y python3-devel postgresql-devel gcc && \
+ARG devDeps
+
+RUN microdnf install -y $devDeps                            && \
     pip3 install virtualenv                                 && \
     mkdir -p /opt/app-root                                  && \
     chown 1001:0 /opt/app-root
@@ -23,11 +28,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS base
 
 USER 0
 
+ARG deps
+
 WORKDIR /opt/app-root
 
 COPY --chown=1001:0 --from=build /opt/app-root /opt/app-root
 
-RUN microdnf install -y python3 libpq procps-ng && \
+RUN microdnf install -y $deps && \
     chown 1001:0 /opt/app-root
 
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN virtualenv .                          && \
     bin/pip install -r requirements.txt . && \
     rm -rf \~
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as base
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS base
 
 USER 0
 
@@ -37,7 +37,7 @@ ENV PATH="/opt/app-root/bin:$PATH"
 # Set the default command for the resulting image
 CMD python ./app.py
 
-FROM base as test
+FROM base AS test
 
 ADD tests/test_* tests/floorplan_* tests/requirements.txt ./tests/
 

--- a/deployment/build-deploy-common.sh
+++ b/deployment/build-deploy-common.sh
@@ -2,7 +2,7 @@
 
 BUILD_DEPLOY_WORKDIR=$(pwd)
 BACKWARDS_COMPATIBILITY="${BACKWARDS_COMPATIBILITY:-true}"
-BACKWARDS_COMPATIBILITY_TAGS="latest qa"
+BACKWARDS_COMPATIBILITY_TAGS="qa"
 REQUIRED_REGISTRIES="quay redhat"
 REQUIRED_REGISTRIES_LOCAL="redhat"
 LOCAL_BUILD="${LOCAL_BUILD:-false}"
@@ -241,6 +241,8 @@ build_deploy_main() {
 
     if ! local_build; then
         push_image "$IMAGE_TAG"
+        tag_image "latest"
+        push_image "latest"
     fi
 
     # To enable backwards compatibility with ci, qa, and smoke, always push latest and qa tags


### PR DESCRIPTION
Tags image build for main branch as `latest` and pushes it to the Quay.

Refactors Dockerfile to extract dependencies into ARGs/environment variables that will be used for further package querying.

RHICOMPL-3284