### PR TITLE
ci: automate image updates

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -1,0 +1,31 @@
+name: Regular base image update check
+on:
+  schedule:
+    - cron: "5 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install skopeo
+        run: sudo apt-get install -y skopeo
+      - name: Check change
+        run: |
+          base=$(grep -Po '(?<=FROM )([^\s]*)(?= AS base)' Dockerfile)
+          skopeo inspect "docker://$base" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          docker run --rm quay.io/cloudservices/floorist:latest sh -c \
+            'microdnf update $deps > /dev/null; rpm -q $deps | sort | sha256sum' \
+            >> .baseimagedigest
+      - name: Do change if the digest changed
+        run: |
+          git config user.name 'Update-a-Bot'
+          git config user.email 'insights@redhat.com'
+          git add .baseimagedigest
+          git commit -m "chore(image): update and rebuild image" || echo "No new changes"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'chore(image): update base image'


### PR DESCRIPTION
Create daily GitHub Action that would check base image and dependent packages for updates.
If any of those changes then it would create a PR updating the digest. Subsequent merge would kick in an image rebuild.

RHICOMPL-3284