### PR TITLE
fix(CI): use jq in checkimage

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Check change
         run: |
           base=$(grep -Po '(?<=FROM )([^\s]*)(?= AS base)' Dockerfile)
-          skopeo inspect "docker://$base" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          skopeo inspect "docker://$base" | jq .Digest --raw-output > .baseimagedigest
           docker run --rm -u 0 quay.io/cloudservices/floorist:latest sh -c \
             'microdnf update -y $(cat /opt/installedpackages) > /dev/null; rpm -q $(cat /opt/installedpackages) | sort | sha256sum | cut -d " " -f 1' \
             >> .baseimagedigest


### PR DESCRIPTION
Use jq to query for image digest to remove the need to rely on skopeo inspect output having json keys in particular order. RHINENG-13679