### PR TITLE
fix: Renovate/Mintmaker - Add major update type to pip requirements renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
         "packageRules": [
             {
                 "matchUpdateTypes": [
+                    "major",
                     "minor",
                     "patch"
                 ],


### PR DESCRIPTION
This will help us to test the requirements changes easily.