### PR TITLE
fix(ci): Fix docker-compose tests + updated readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ There's two ways of running the tests, you can run them locally using `pytest` f
 ### Running tests locally
 
 ```bash
+# Create venv
+python3 -m venv .venv_tests && source .venv_tests/bin/activate
 
 # Install with Test dependencies
 # You might have to escape the square brackets (e.g. when using `zsh`)
@@ -183,11 +185,11 @@ pip install -e .[test] -r requirements.txt
 # Set the environment config file
 cp tests/env.yaml.example tests/env.yaml
 
-# Bring up all the required containers
+# Bring up all the required containers (or use podman-compose)
 docker compose -f tests/docker-compose.yml up -d
 
 # Run the tests locally
-pytest tests
+pytest -vvv -s tests
 
 # Tear-down
 docker compose -f tests/docker-compose.yml down

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -176,7 +176,7 @@ echo '===================================='
 echo '===     Running Tests           ===='
 echo '===================================='
 set +e
-${DOCKER} exec "$TEST_CONTAINER_ID" /bin/bash -c "pytest --junitxml=test-report.xml tests"
+${DOCKER} exec "$TEST_CONTAINER_ID" /bin/bash -c "pytest -vvv -s --junitxml=test-report.xml tests"
 TEST_RESULT=$?
 set -e
 # Copy test reports

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db:
-    image: quay.io/cloudservices/centos-postgresql-12
+    image: quay.io/cloudservices/centos-postgresql-12:20210722-70dc4d3
     restart: always
     environment:
       - POSTGRESQL_PASSWORD=floorist
@@ -16,7 +16,7 @@ services:
         target: /opt/app-root/src/postgresql-start/enable-extensions.sh:z
 
   minio:
-    image: quay.io/minio/minio
+    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
     command: server /data
     ports:
       - 9000:9000
@@ -24,14 +24,14 @@ services:
       - MINIO_ACCESS_KEY=floorist
       - MINIO_SECRET_KEY=floorist
   createbucket:
-    image: quay.io/minio/mc
+    image: quay.io/minio/mc:RELEASE.2025-05-21T01-59-54Z
     depends_on:
       - minio
     links:
       - minio
     entrypoint: /bin/sh
     command: -c '
-      until /usr/bin/mc config host add myminio http://minio:9000 floorist floorist >/dev/null; do sleep 1; done ;
+      until /usr/bin/mc alias set myminio http://minio:9000 floorist floorist >/dev/null; do sleep 1; done ;
       /usr/bin/mc mb myminio/floorist;
-      /usr/bin/mc policy set download myminio/floorist;
+      /usr/bin/mc anonymous set download myminio/floorist;
       exit 0;'


### PR DESCRIPTION
## Summary by Sourcery

Fix docker-compose test setup issues and improve test run documentation and scripts.

Bug Fixes:
- Pin specific PostgreSQL and Minio image tags in the Docker Compose test configuration
- Replace 'mc config host add' with 'mc alias set' and change bucket policy command to 'mc anonymous set download' for Minio setup

Documentation:
- Add instructions to create and activate a Python virtual environment before running tests
- Note podman-compose as an alternative and update pytest invocation in README to use verbose and streaming flags

Tests:
- Update run-tests.sh to invoke pytest with '-vvv -s' flags while preserving JUnit XML report generation