### PR TITLE
fix(ci): Update minio/mc images used for testing

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,8 +9,8 @@ TEST_CONTAINER_NAME="floorist-test-${IMAGE_TAG}"
 NETWORK="floorist-test-${IMAGE_TAG}"
 
 POSTGRES_IMAGE="quay.io/cloudservices/centos-postgresql-12:20210722-70dc4d3"
-MINIO_IMAGE="quay.io/cloudservices/minio:RELEASE.2025-06-13T11-33-47Z"
-MINIO_CLIENT_IMAGE="quay.io/cloudservices/mc:RELEASE.2025-05-21T01-59-54Z"
+MINIO_IMAGE="quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z"
+MINIO_CLIENT_IMAGE="quay.io/minio/mc:RELEASE.2025-05-21T01-59-54Z"
 MINIO_BUCKET_NAME="floorist"
 MINIO_REGION="us-east-1"
 


### PR DESCRIPTION
## Summary by Sourcery

Use official MinIO images in CI test setup by switching from quay.io/cloudservices to quay.io/minio for both server and client binaries

CI:
- Update MINIO_IMAGE to quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
- Update MINIO_CLIENT_IMAGE to quay.io/minio/mc:RELEASE.2025-05-21T01-59-54Z