### PR TITLE
[RHINENG-26184] Bump create-pull-request GH action

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -26,6 +26,6 @@ jobs:
           git add .baseimagedigest
           git commit -m "chore(image): update and rebuild image" || echo "No new changes"
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           title: 'chore(image): update base image'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the checkimage workflow to use peter-evans/create-pull-request@v8 instead of v7.