### PR TITLE
Improve performance with lower level UUID handling

### DIFF
--- a/src/floorist/floorist.py
+++ b/src/floorist/floorist.py
@@ -7,14 +7,14 @@ from pandas import DataFrame
 
 from floorist.config import get_config, Config
 from os import environ
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy import exc as sqlalchemy_exc
-from uuid import UUID
 
 import awswrangler as wr
 import boto3
 import logging
 import pandas as pd
+import psycopg2.extensions
 import time
 import yaml
 
@@ -103,11 +103,24 @@ class S3Client:
 
 
 class DatabaseClient:
+    _uuid_caster = psycopg2.extensions.new_type(
+        (2950,),  # PostgreSQL OID for UUID type: select oid from pg_type where typname='uuid'
+        "UUID_AS_STRING",
+        psycopg2.STRING,
+    )
+
     def __init__(self, config: Config):
         self.engine = create_engine(
             f"postgresql://{config.database_username}:{config.database_password}@{config.database_hostname}/{config.database_name}"
         )
+        event.listen(self.engine, "connect", self._register_uuid_caster)
         self.conn = self.engine.connect().execution_options(stream_results=True)
+
+    @staticmethod
+    def _register_uuid_caster(dbapi_conn, connection_record):
+        # Convert all UUID types to strings automatically.  The s3.write_parquet method will fail if
+        # columns remain the UUID type
+        psycopg2.extensions.register_type(DatabaseClient._uuid_caster, dbapi_conn)
 
     def execute_query(self, query, chunksize) -> Generator[DataFrame, None, None]:
         result = pd.read_sql(query, self.conn, chunksize=chunksize)
@@ -137,19 +150,8 @@ class DumpExecutor:
         logging.debug("[Dump #%d] Query: %s", dump_count, query)
         cursor = self.db_client.execute_query(query, chunksize)
 
-        uuids = {}
-
         chunk = 1
         for data in cursor:
-            if len(uuids) == 0 and len(data) > 0:
-                # Detect any columns with UUID
-                for column in data:
-                    if isinstance(data[column][0], UUID):
-                        logging.debug("[Dump #%d] UUID column detected: %s", dump_count, column)
-                        uuids[column] = "string"
-
-            # Convert any columns with UUID type to string
-            data = data.astype(uuids)
             self.s3_client.write_parquet(data, target, path)
             if len(data) > 0:
                 logging.info("[Dump #%d] Written parquet chunk #%d", dump_count, chunk)

--- a/src/floorist/floorist.py
+++ b/src/floorist/floorist.py
@@ -24,6 +24,10 @@ RETRY_DELAY = 5  # seconds
 
 LOG_FMT = "[%(asctime)s] [%(levelname)s] %(message)s"
 
+# Stable OID for the UUID type, assigned in src/include/catalog/pg_type.dat in the PostgreSQL source.
+# Verify with: SELECT oid FROM pg_type WHERE typname = 'uuid'
+_PG_UUID_OID = 2950
+
 _RETRYABLE_DB_ERROR_PATTERNS = (
     "SerializationFailure",
     "conflict with recovery",
@@ -104,20 +108,25 @@ class S3Client:
 
 class DatabaseClient:
     _uuid_caster = psycopg2.extensions.new_type(
-        (2950,),  # PostgreSQL OID for UUID type: select oid from pg_type where typname='uuid'
+        (_PG_UUID_OID,),
         "UUID_AS_STRING",
         psycopg2.STRING,
     )
 
     def __init__(self, config: Config):
         self.engine = create_engine(
-            f"postgresql://{config.database_username}:{config.database_password}@{config.database_hostname}/{config.database_name}"
+            f"postgresql+psycopg2://{config.database_username}:{config.database_password}@{config.database_hostname}/{config.database_name}"
         )
         event.listen(self.engine, "connect", self._register_uuid_caster)
         self.conn = self.engine.connect().execution_options(stream_results=True)
 
     @staticmethod
     def _register_uuid_caster(dbapi_conn, connection_record):
+        if not isinstance(dbapi_conn, psycopg2.extensions.connection):
+            raise TypeError(
+                f"Expected a psycopg2 connection, got {type(dbapi_conn).__name__}. "
+                "The UUID type caster requires psycopg2."
+            )
         # Convert all UUID types to strings automatically.  The s3.write_parquet method will fail if
         # columns remain the UUID type
         psycopg2.extensions.register_type(DatabaseClient._uuid_caster, dbapi_conn)

--- a/tests/test_floorist_standalone.py
+++ b/tests/test_floorist_standalone.py
@@ -278,12 +278,14 @@ class TestS3BucketFallback:
                 environ[key] = settings[key]
 
     @patch("floorist.floorist.DumpExecutor")
+    @patch("floorist.floorist.event")
     @patch("floorist.floorist.create_engine")
     @patch("floorist.floorist.wr.s3.list_directories")
     def test_list_directories_retries_with_trailing_slash(
         self,
         mock_s3_list,
         mock_create_engine,
+        mock_event,
         mock_executor,
     ):
         mock_s3_list.side_effect = [
@@ -310,6 +312,7 @@ class TestS3BucketFallback:
         instance.execute.assert_called()
 
     @patch("floorist.floorist.DumpExecutor")
+    @patch("floorist.floorist.event")
     # Defensive mock
     @patch("floorist.floorist.create_engine")
     @patch("floorist.floorist.wr.s3.list_directories")
@@ -317,6 +320,7 @@ class TestS3BucketFallback:
         self,
         mock_s3_list,
         mock_create_engine,
+        mock_event,
         mock_executor,
     ):
         # Simulate a non-AccessDenied ClientError from S3, e.g. NoSuchBucket
@@ -340,6 +344,7 @@ class TestS3BucketFallback:
         mock_executor.return_value.execute.assert_not_called()
 
     @patch("floorist.floorist.DumpExecutor")
+    @patch("floorist.floorist.event")
     # Defensive mock
     @patch("floorist.floorist.create_engine")
     @patch("floorist.floorist.wr.s3.list_directories")
@@ -347,6 +352,7 @@ class TestS3BucketFallback:
         self,
         mock_s3_list,
         mock_create_engine,
+        mock_event,
         mock_executor,
     ):
         mock_s3_list.side_effect = [


### PR DESCRIPTION
The s3.write_parquet method fails if columns remain as the UUID type. Previously, Floorist handled this issue with a heuristic approach by sampling the first row of each column and seeing if it was of type UUID.

This patch handles the problem at the database driver level.  It adds a type handler that tells the driver to automatically cast the UUID type to a string.

Handling the issue at the driver level results in a small performance improvement: about 2%.  It's also a cleaner approach since the issue is handled once (at connection time) rather than for every chunk that is read.

<details>
<summary>bench-abab.py</summary>

```python
#!/usr/bin/env python3
"""ABAB benchmarking harness for comparing floorist variants.

Runs integration tests in round-robin order across worktrees to minimize
the effect of system load drift, thermal throttling, and cache warming.

Usage:
    python bench-abab.py [--iterations N] [--test-filter PATTERN]
"""

import argparse
import statistics
import subprocess
import sys
import tempfile
import xml.etree.ElementTree as ET
from collections import defaultdict
from pathlib import Path

PYTEST = ".venv/bin/pytest"
TEST_FILE = "tests/test_floorist.py"

VARIANTS = {
    "oo": "/home/awood/devel/floorist",
    "psycopg2": "/home/awood/devel/floorist-performance",
}


def run_test(variant_name, worktree, junit_path, test_filter=None):
    cmd = [PYTEST, TEST_FILE, "-vv", "-s", f"--junit-xml={junit_path}"]
    if test_filter:
        cmd.extend(["-k", test_filter])

    result = subprocess.run(cmd, capture_output=True, text=True, cwd=worktree)
    return result.returncode == 0


def parse_junit(junit_path):
    tree = ET.parse(junit_path)
    timings = {}
    for testcase in tree.iter("testcase"):
        name = testcase.get("name")
        time_s = float(testcase.get("time", 0))
        skipped = testcase.find("skipped")
        if skipped is None:
            timings[name] = time_s
    return timings


def compute_stats(times):
    n = len(times)
    if n == 0:
        return {}
    return {
        "mean": statistics.mean(times),
        "median": statistics.median(times),
        "stdev": statistics.stdev(times) if n > 1 else 0.0,
        "min": min(times),
        "max": max(times),
        "n": n,
    }


def print_variant_report(variant_name, all_timings, iterations):
    if not all_timings:
        print(f"\n  {variant_name}: No results collected.")
        return

    name_width = max(len(name) for name in all_timings)
    col_w = 10

    header = (
        f"{'Test':<{name_width}}  "
        f"{'Mean':>{col_w}}  "
        f"{'Median':>{col_w}}  "
        f"{'StdDev':>{col_w}}  "
        f"{'Min':>{col_w}}  "
        f"{'Max':>{col_w}}  "
        f"{'Runs':>{5}}"
    )
    sep = "=" * len(header)

    print(f"\n{sep}")
    print(f"  {variant_name} ({iterations} iterations)")
    print(sep)
    print(header)
    print("-" * len(header))

    suite_totals = []

    for name in sorted(all_timings):
        times = all_timings[name]
        s = compute_stats(times)
        print(
            f"{name:<{name_width}}  "
            f"{s['mean']:>{col_w}.4f}  "
            f"{s['median']:>{col_w}.4f}  "
            f"{s['stdev']:>{col_w}.4f}  "
            f"{s['min']:>{col_w}.4f}  "
            f"{s['max']:>{col_w}.4f}  "
            f"{s['n']:>{5}}"
        )
        for i, t in enumerate(times):
            if i < len(suite_totals):
                suite_totals[i] += t
            else:
                suite_totals.append(t)

    if suite_totals:
        s = compute_stats(suite_totals)
        print("-" * len(header))
        print(
            f"{'TOTAL':<{name_width}}  "
            f"{s['mean']:>{col_w}.4f}  "
            f"{s['median']:>{col_w}.4f}  "
            f"{s['stdev']:>{col_w}.4f}  "
            f"{s['min']:>{col_w}.4f}  "
            f"{s['max']:>{col_w}.4f}  "
            f"{s['n']:>{5}}"
        )

    return suite_totals


def print_comparison(all_results, baseline="master"):
    test_names = set()
    for timings in all_results.values():
        test_names.update(timings.keys())
    test_names = sorted(test_names)

    variant_names = list(all_results.keys())
    if baseline not in variant_names:
        baseline = variant_names[0]

    col_w = 12
    name_width = max(len(name) for name in test_names) if test_names else 20

    header_parts = [f"{'Test':<{name_width}}"]
    for v in variant_names:
        header_parts.append(f"{v + ' med':>{col_w}}")
    for v in variant_names:
        if v != baseline:
            header_parts.append(f"{v + ' vs ' + baseline:>{col_w}}")
    header = "  ".join(header_parts)
    sep = "=" * len(header)

    print(f"\n{sep}")
    print(f"  Cross-variant comparison (median, baseline={baseline})")
    print(sep)
    print(header)
    print("-" * len(header))

    suite_medians = {}
    for v in variant_names:
        totals = []
        for name in test_names:
            times = all_results[v].get(name, [])
            if times:
                for i, t in enumerate(times):
                    if i < len(totals):
                        totals[i] += t
                    else:
                        totals.append(t)
        suite_medians[v] = statistics.median(totals) if totals else 0

    for name in test_names:
        medians = {}
        for v in variant_names:
            times = all_results[v].get(name, [])
            medians[v] = statistics.median(times) if times else None

        parts = [f"{name:<{name_width}}"]
        for v in variant_names:
            if medians[v] is not None:
                parts.append(f"{medians[v]:>{col_w}.4f}")
            else:
                parts.append(f"{'n/a':>{col_w}}")

        baseline_med = medians.get(baseline)
        for v in variant_names:
            if v == baseline:
                continue
            if medians[v] is not None and baseline_med and baseline_med > 0.001:
                pct = ((medians[v] - baseline_med) / baseline_med) * 100
                parts.append(f"{pct:>{col_w - 1}.1f}%")
            else:
                parts.append(f"{'n/a':>{col_w}}")

        print("  ".join(parts))

    # Suite total row
    parts = [f"{'TOTAL':<{name_width}}"]
    for v in variant_names:
        parts.append(f"{suite_medians[v]:>{col_w}.4f}")
    baseline_total = suite_medians.get(baseline, 0)
    for v in variant_names:
        if v == baseline:
            continue
        if baseline_total > 0:
            pct = ((suite_medians[v] - baseline_total) / baseline_total) * 100
            parts.append(f"{pct:>{col_w - 1}.1f}%")
        else:
            parts.append(f"{'n/a':>{col_w}}")
    print("-" * len(header))
    print("  ".join(parts))


def main():
    parser = argparse.ArgumentParser(description="ABCABC benchmark across floorist variants")
    parser.add_argument("-n", "--iterations", type=int, default=10, help="Number of iterations per variant (default: 10)")
    parser.add_argument("-k", "--test-filter", type=str, default=None, help="pytest -k filter expression")
    args = parser.parse_args()

    all_results = {name: defaultdict(list) for name in VARIANTS}
    failures = {name: 0 for name in VARIANTS}
    variant_order = list(VARIANTS.keys())

    with tempfile.TemporaryDirectory() as tmpdir:
        for i in range(1, args.iterations + 1):
            for variant_name in variant_order:
                worktree = VARIANTS[variant_name]
                junit_path = Path(tmpdir) / f"{variant_name}_{i}.xml"

                print(f"[Iteration {i}/{args.iterations}] {variant_name}...", end=" ", flush=True)

                success = run_test(variant_name, worktree, junit_path, args.test_filter)
                if success:
                    timings = parse_junit(junit_path)
                    for name, duration in timings.items():
                        all_results[variant_name][name].append(duration)
                    total = sum(timings.values())
                    print(f"{total:.1f}s")
                else:
                    failures[variant_name] += 1
                    print("FAILED")
                    if junit_path.exists():
                        timings = parse_junit(junit_path)
                        for name, duration in timings.items():
                            all_results[variant_name][name].append(duration)

    # Per-variant reports
    for variant_name in variant_order:
        print_variant_report(variant_name, all_results[variant_name], args.iterations)

    # Cross-variant comparison
    print_comparison(all_results, baseline="master")

    # Failure summary
    total_failures = sum(failures.values())
    if total_failures:
        print(f"\nFailures: {failures}")
        sys.exit(1)


if __name__ == "__main__":
    main()
```
</details>


<details>
<summary>300 iterations</summary>

```
=====================================================================================================================
  oo (300 iterations)
=====================================================================================================================
Test                                                      Mean      Median      StdDev         Min         Max   Runs
---------------------------------------------------------------------------------------------------------------------
test_floorplan_undefined_aws_endpoint                   0.0018      0.0010      0.0013      0.0010      0.0060    300
test_floorplan_valid                                    0.3227      0.3140      0.0459      0.2690      0.7680    300
test_floorplan_with_custom_chunksize                    2.7743      2.7345      0.1677      2.5380      3.7110    300
test_floorplan_with_empty_dataset                       0.3282      0.3150      0.0751      0.2740      1.3400    300
test_floorplan_with_invalid_prefix                      0.2478      0.2320      0.1065      0.1950      1.2560    300
test_floorplan_with_invalid_query                       0.1735      0.1580      0.1074      0.1300      1.1680    300
test_floorplan_with_large_result                       32.5605     32.5495      0.2226     32.0130     33.5360    300
test_floorplan_with_multiple_dumps                      0.3365      0.3170      0.1078      0.2810      1.3840    300
test_floorplan_with_one_failing_dump                    0.3510      0.3120      0.2939      0.2610      4.8890    300
test_floorplan_with_zero_chunksize                      0.5379      0.5270      0.0874      0.4700      1.5220    300
test_floorplan_without_prefix                           0.1565      0.1470      0.0882      0.1190      1.1560    300
test_floorplan_without_query                            0.1846      0.1750      0.0682      0.1450      1.1790    300
test_invalid_pg_credentials                             0.2183      0.2110      0.0633      0.1780      1.2020    300
test_invalid_pg_database                                0.1677      0.1465      0.1463      0.1160      2.1750    300
test_invalid_s3_credentials                             0.0870      0.0850      0.0066      0.0810      0.1180    300
test_missing_floorplan                                  0.0017      0.0010      0.0012      0.0010      0.0060    300
test_missing_pg_credentials[POSTGRESQL_DATABASE]        0.0011      0.0010      0.0003      0.0010      0.0020    300
test_missing_pg_credentials[POSTGRESQL_PASSWORD]        0.0011      0.0010      0.0003      0.0010      0.0020    300
test_missing_pg_credentials[POSTGRESQL_USER]            0.0011      0.0010      0.0003      0.0010      0.0030    300
test_missing_pg_credentials[POSTGRES_SERVICE_HOST]      0.0013      0.0010      0.0005      0.0010      0.0030    300
test_missing_s3_bucket                                  0.0847      0.0830      0.0055      0.0780      0.1120    300
test_unset_floorplan                                    0.0021      0.0020      0.0014      0.0010      0.0060    300
test_unset_s3_bucket                                    0.0011      0.0010      0.0003      0.0010      0.0020    300
test_unset_s3_credentials[AWS_ACCESS_KEY_ID]            0.0020      0.0020      0.0001      0.0020      0.0030    300
test_unset_s3_credentials[AWS_REGION]                   0.0011      0.0010      0.0002      0.0010      0.0020    300
test_unset_s3_credentials[AWS_SECRET_ACCESS_KEY]        0.0011      0.0010      0.0003      0.0010      0.0020    300
---------------------------------------------------------------------------------------------------------------------
TOTAL                                                  38.5470     38.4555      0.5311     37.7290     43.0480    300

=====================================================================================================================
  psycopg2 (300 iterations)
=====================================================================================================================
Test                                                      Mean      Median      StdDev         Min         Max   Runs
---------------------------------------------------------------------------------------------------------------------
test_floorplan_undefined_aws_endpoint                   0.0017      0.0010      0.0012      0.0010      0.0060    300
test_floorplan_valid                                    0.3253      0.3120      0.0893      0.2690      1.3370    300
test_floorplan_with_custom_chunksize                    2.7166      2.6835      0.1529      2.4840      3.6870    300
test_floorplan_with_empty_dataset                       0.3244      0.3115      0.0891      0.2680      1.3300    300
test_floorplan_with_invalid_prefix                      0.2414      0.2310      0.0997      0.1890      1.5860    300
test_floorplan_with_invalid_query                       0.1782      0.1575      0.1315      0.1250      1.1800    300
test_floorplan_with_large_result                       31.8279     31.8045      0.2343     31.3200     32.9680    300
test_floorplan_with_multiple_dumps                      0.3377      0.3160      0.1320      0.2750      1.3340    300
test_floorplan_with_one_failing_dump                    0.3373      0.3115      0.1458      0.2680      1.3550    300
test_floorplan_with_zero_chunksize                      0.5292      0.5230      0.0373      0.4570      0.7960    300
test_floorplan_without_prefix                           0.1549      0.1460      0.0909      0.1180      1.3090    300
test_floorplan_without_query                            0.1855      0.1760      0.0665      0.1440      1.1810    300
test_invalid_pg_credentials                             0.2273      0.2110      0.1050      0.1790      1.2140    300
test_invalid_pg_database                                0.1601      0.1460      0.1111      0.1160      1.3790    300
test_invalid_s3_credentials                             0.0848      0.0820      0.0064      0.0780      0.1140    300
test_missing_floorplan                                  0.0017      0.0010      0.0012      0.0010      0.0060    300
test_missing_pg_credentials[POSTGRESQL_DATABASE]        0.0011      0.0010      0.0003      0.0010      0.0020    300
test_missing_pg_credentials[POSTGRESQL_PASSWORD]        0.0011      0.0010      0.0003      0.0010      0.0020    300
test_missing_pg_credentials[POSTGRESQL_USER]            0.0011      0.0010      0.0003      0.0010      0.0030    300
test_missing_pg_credentials[POSTGRES_SERVICE_HOST]      0.0013      0.0010      0.0005      0.0010      0.0030    300
test_missing_s3_bucket                                  0.0846      0.0820      0.0067      0.0770      0.1190    300
test_unset_floorplan                                    0.0020      0.0020      0.0013      0.0010      0.0060    300
test_unset_s3_bucket                                    0.0011      0.0010      0.0003      0.0010      0.0020    300
test_unset_s3_credentials[AWS_ACCESS_KEY_ID]            0.0020      0.0020      0.0001      0.0020      0.0030    300
test_unset_s3_credentials[AWS_REGION]                   0.0010      0.0010      0.0002      0.0010      0.0020    300
test_unset_s3_credentials[AWS_SECRET_ACCESS_KEY]        0.0011      0.0010      0.0003      0.0010      0.0020    300
---------------------------------------------------------------------------------------------------------------------
TOTAL                                                  37.7302     37.6255      0.4714     37.0230     40.8990    300

==============================================================================================
  Cross-variant comparison (median, baseline=oo)
==============================================================================================
Test                                                      oo med  psycopg2 med  psycopg2 vs oo
----------------------------------------------------------------------------------------------
test_floorplan_undefined_aws_endpoint                     0.0010        0.0010           n/a
test_floorplan_valid                                      0.3140        0.3120         -0.6%
test_floorplan_with_custom_chunksize                      2.7345        2.6835         -1.9%
test_floorplan_with_empty_dataset                         0.3150        0.3115         -1.1%
test_floorplan_with_invalid_prefix                        0.2320        0.2310         -0.4%
test_floorplan_with_invalid_query                         0.1580        0.1575         -0.3%
test_floorplan_with_large_result                         32.5495       31.8045         -2.3%
test_floorplan_with_multiple_dumps                        0.3170        0.3160         -0.3%
test_floorplan_with_one_failing_dump                      0.3120        0.3115         -0.2%
test_floorplan_with_zero_chunksize                        0.5270        0.5230         -0.8%
test_floorplan_without_prefix                             0.1470        0.1460         -0.7%
test_floorplan_without_query                              0.1750        0.1760          0.6%
test_invalid_pg_credentials                               0.2110        0.2110          0.0%
test_invalid_pg_database                                  0.1465        0.1460         -0.3%
test_invalid_s3_credentials                               0.0850        0.0820         -3.5%
test_missing_floorplan                                    0.0010        0.0010           n/a
test_missing_pg_credentials[POSTGRESQL_DATABASE]          0.0010        0.0010           n/a
test_missing_pg_credentials[POSTGRESQL_PASSWORD]          0.0010        0.0010           n/a
test_missing_pg_credentials[POSTGRESQL_USER]              0.0010        0.0010           n/a
test_missing_pg_credentials[POSTGRES_SERVICE_HOST]        0.0010        0.0010           n/a
test_missing_s3_bucket                                    0.0830        0.0820         -1.2%
test_unset_floorplan                                      0.0020        0.0020          0.0%
test_unset_s3_bucket                                      0.0010        0.0010           n/a
test_unset_s3_credentials[AWS_ACCESS_KEY_ID]              0.0020        0.0020          0.0%
test_unset_s3_credentials[AWS_REGION]                     0.0010        0.0010           n/a
test_unset_s3_credentials[AWS_SECRET_ACCESS_KEY]          0.0010        0.0010           n/a
----------------------------------------------------------------------------------------------
TOTAL                                                    38.4555       37.6255         -2.2%
```

</summary>

## Summary by Sourcery

Handle PostgreSQL UUID columns at the database driver level instead of per-chunk conversion.

Enhancements:
- Register a psycopg2 UUID type caster on connection so UUID columns are automatically returned as strings.
- Remove per-chunk UUID detection and casting in the parquet dump path, simplifying chunk processing and improving performance.