### PR TITLE
fix: parse S3 target URI when creating empty export folders

### DIFF
--- a/src/floorist/floorist.py
+++ b/src/floorist/floorist.py
@@ -100,7 +100,14 @@ class S3Client:
         if len(data) > 0:
             wr.s3.to_parquet(data, target, index=False, compression="gzip", dataset=True, mode="append")
         else:
-            wr._utils.client("s3").put_object(Bucket=self.bucket_name, Body="", Key=path + "/")
+            name = self.bucket_name.rstrip("/")
+            if "/" in name:
+                bucket, prefix = name.split("/", 1)
+                key = f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+            else:
+                bucket = name
+                key = path
+            wr._utils.client("s3").put_object(Bucket=bucket, Body="", Key=f"{key.rstrip('/')}/")
 
     def cleanup(self, target):
         wr.s3.delete_objects(target)

--- a/tests/test_floorist_standalone.py
+++ b/tests/test_floorist_standalone.py
@@ -2,8 +2,9 @@ import botocore.exceptions
 import pandas as pd
 import pytest
 import yaml
+from datetime import date
 
-from floorist.floorist import main, RetryPolicy, RetryResult, DumpExecutor, MAX_RETRIES, RETRY_DELAY
+from floorist.floorist import main, RetryPolicy, RetryResult, DumpExecutor, MAX_RETRIES, RETRY_DELAY, S3Client
 from os import environ
 from sqlalchemy import exc as sqlalchemy_exc
 from unittest.mock import Mock, patch
@@ -399,4 +400,78 @@ class TestTransactionIsolation:
         # NOT: read_sql, read_sql, commit, commit (batched)
         assert call_order == ["read_sql", "commit", "read_sql", "commit"], (
             f"Expected interleaved pattern, got: {call_order}"
+        )
+
+
+@pytest.mark.standalone
+class TestWriteParquetEmptyResult:
+    @staticmethod
+    def _s3_client(bucket_name, *, region="us-east-1", endpoint="http://minio:9000"):
+        config = Mock()
+        config.bucket_name = bucket_name
+        config.bucket_url = endpoint
+        config.bucket_access_key = "access-key"
+        config.bucket_secret_key = "secret-key"
+        config.bucket_region = region
+        with patch("floorist.floorist.boto3.setup_default_session"):
+            return S3Client(config)
+
+    @patch("floorist.floorist.date")
+    @patch("floorist.floorist.wr.s3.to_parquet")
+    @patch("floorist.floorist.wr._utils.client")
+    def test_empty_export_splits_bucket_with_embedded_prefix(self, mock_client_fn, mock_to_parquet, mock_date):
+        """AWS_BUCKET may embed a key prefix; empty exports must still write a folder marker."""
+        mock_date.today.return_value = date(2026, 6, 3)
+        mock_s3 = Mock()
+        mock_client_fn.return_value = mock_s3
+        client = self._s3_client(
+            "export-bucket/object-prefix/",
+            region="us-west-2",
+            endpoint="https://s3.us-west-2.amazonaws.com",
+        )
+
+        path, target = client.make_path("metrics/daily_export")
+        client.write_parquet(pd.DataFrame(), target, path)
+
+        mock_to_parquet.assert_not_called()
+        mock_s3.put_object.assert_called_once_with(
+            Bucket="export-bucket",
+            Body="",
+            Key="object-prefix/metrics/daily_export/year_created=2026/month_created=6/day_created=3/",
+        )
+
+    @patch("floorist.floorist.date")
+    @patch("floorist.floorist.wr.s3.to_parquet")
+    @patch("floorist.floorist.wr._utils.client")
+    def test_empty_export_keeps_simple_bucket_from_make_path_target(self, mock_client_fn, mock_to_parquet, mock_date):
+        mock_date.today.return_value = date(2026, 6, 3)
+        mock_s3 = Mock()
+        mock_client_fn.return_value = mock_s3
+        client = self._s3_client("floorist")
+
+        path, target = client.make_path("empty")
+        client.write_parquet(pd.DataFrame(), target, path)
+
+        mock_to_parquet.assert_not_called()
+        mock_s3.put_object.assert_called_once_with(
+            Bucket="floorist",
+            Body="",
+            Key="empty/year_created=2026/month_created=6/day_created=3/",
+        )
+
+    @patch("floorist.floorist.wr.s3.to_parquet")
+    @patch("floorist.floorist.wr._utils.client")
+    def test_nonempty_export_still_uses_awswrangler(self, mock_client_fn, mock_to_parquet):
+        mock_s3 = Mock()
+        mock_client_fn.return_value = mock_s3
+        client = self._s3_client("export-bucket/object-prefix/")
+        path = "metrics/snapshots/year_created=2026/month_created=6/day_created=3"
+        target = f"s3://{client.bucket_name}/{path}"
+        data = pd.DataFrame({"id": [1]})
+
+        client.write_parquet(data, target, path)
+
+        mock_s3.put_object.assert_not_called()
+        mock_to_parquet.assert_called_once_with(
+            data, target, index=False, compression="gzip", dataset=True, mode="append"
         )


### PR DESCRIPTION
## Summary

When a floorplan query returns no rows, Floorist creates a folder marker via boto3 put_object. That path used AWS_BUCKET verbatim, which breaks for Dataverse Snowpipe credentials where the bucket secret combines bucket and prefix (e.g. dataverse-dev-snowpipe/source-dev-subscriptionwatch/).

Non-empty exports already worked because awswrangler accepts the combined s3:// target. Align the empty-result branch by splitting bucket and key from the same target URI used for parquet writes.

## Solution
- Add `_parse_s3_uri()` to split `s3://` targets into `(bucket, key)`.
- Use the parsed bucket/key when creating the empty folder marker so Snowpipe and simple MinIO bucket configs behave consistently.

## Summary by Sourcery

Align S3 empty-result export behavior with non-empty exports by deriving the bucket and key from the target S3 URI instead of using the configured bucket name verbatim.

Bug Fixes:
- Ensure empty parquet exports correctly split bucket and key from S3 URIs where the configured bucket includes a key prefix (e.g., Snowpipe-style combined bucket and prefix).

Tests:
- Add unit tests for parsing S3 URIs into bucket and key components, including Snowpipe-style buckets with prefixes.
- Add regression tests verifying empty parquet exports use the parsed bucket from the target URI for both prefixed and simple bucket configurations.